### PR TITLE
Fix directory change bug in ‘EXPORT-TO-PNG.sh’

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Based on Idea11 icons from [pharo-project](https://github.com/pharo-project/phar
 Created using Inkscape.
 
 The folder ```svg``` contains icons in format svg.
-PNG files are generated from these svg files executing the script ```scripts/export-to-png.sh```
+PNG files are generated from these svg files executing the script ```scripts/EXPORT-TO-PNG.sh```

--- a/scripts/EXPORT-TO-PNG.sh
+++ b/scripts/EXPORT-TO-PNG.sh
@@ -4,7 +4,7 @@
 mkdir ../png-scale1.0;
 cd ../svg;
 find . -name "*.png" -exec sh -c 'mv ${1%} ../png-scale1.0/${1%}' _ {} \;
-cd ..
+cd ../scripts
 
 [ -d "../png-scale1.5" ] && rm -rf ../png-scale1.5
 ./create-png-scale1.5.sh;
@@ -12,7 +12,7 @@ mkdir ../png-scale1.5;
 cd ../svg;
 find . -name "*.png" -exec sh -c 'mv ${1%} ../png-scale1.5/${1%}' _ {} \;
 
-cd ..
+cd ../scripts
 [ -d "../png-scale2.0" ] && rm -rf ../png-scale2.0
 ./create-png-scale2.0.sh;
 mkdir ../png-scale2.0;

--- a/scripts/create-png-scale1.0.sh
+++ b/scripts/create-png-scale1.0.sh
@@ -10,8 +10,6 @@
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/back.svg --export-type="png" -w 16 -h 16
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/bitbucket.svg --export-type="png" -w 16 -h 16
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/blank.svg --export-type="png" -w 16 -h 1
-/Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/blank10.svg --export-type="png" -w 10 -h 1
-/Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/blank16.svg --export-type="png" -w 16 -h 1
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/book.svg --export-type="png" -w 13 -h 13
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/bottom.svg --export-type="png" -w 16 -h 16
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/branch.svg --export-type="png" -w 16 -h 16

--- a/scripts/create-png-scale1.5.sh
+++ b/scripts/create-png-scale1.5.sh
@@ -10,8 +10,6 @@
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/back.svg --export-type="png" -w 24 -h 24
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/bitbucket.svg --export-type="png" -w 24 -h 24
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/blank.svg --export-type="png" -w 24 -h 2
-/Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/blank10.svg --export-type="png" -w 15 -h 2
-/Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/blank16.svg --export-type="png" -w 24 -h 2
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/book.svg --export-type="png" -w 20 -h 20
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/bottom.svg --export-type="png" -w 24 -h 24
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/branch.svg --export-type="png" -w 24 -h 24

--- a/scripts/create-png-scale2.0.sh
+++ b/scripts/create-png-scale2.0.sh
@@ -10,8 +10,6 @@
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/back.svg --export-type="png" -w 32 -h 32
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/bitbucket.svg --export-type="png" -w 32 -h 32
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/blank.svg --export-type="png" -w 32 -h 2
-/Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/blank10.svg --export-type="png" -w 20 -h 2
-/Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/blank16.svg --export-type="png" -w 32 -h 2
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/book.svg --export-type="png" -w 26 -h 26
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/bottom.svg --export-type="png" -w 32 -h 32
 /Applications/Inkscape.app/Contents/MacOS/inkscape ../svg/branch.svg --export-type="png" -w 32 -h 32


### PR DESCRIPTION
This pull request fixes a bug in ‘EXPORT-TO-PNG.sh’, the ‘cd’ commands after the ‘find’ commands did not change the working directory back to the ‘scripts’ directory. It also corrects the name of the script in the file ‘README.md’ and removes the references to the nonexistent ‘blank10.svg’ and ‘blank16.svg’. 